### PR TITLE
updated discord link

### DIFF
--- a/faqs/contribute.md
+++ b/faqs/contribute.md
@@ -7,4 +7,4 @@ attribution:
     link: https://snakecharmers.ethereum.org
 ---
 
-The ETH Portal Network development effort is an open, multi-team effort. If you're interested in helping contribute towards the desgin and implementation, join the ongoing discussion happening on the `#portal-network` channel on `ETH R&D` discord server. There is also a weekly call, Tuesdays @ [3PM UTC](https://www.worldtimebuddy.com/mst-to-utc-converter?qm=1&lid=7,100,5128581&h=7&date=2021-4-21&sln=9-9.5&hf=1), where we discuss the latest developments and open questions.
+The ETH Portal Network development effort is an open, multi-team effort. If you're interested in helping contribute towards the desgin and implementation, join the ongoing discussion happening on the [Portal Network discord server](https://discord.gg/SHZKdkeJQu). There is also a weekly call, Tuesdays @ [3PM UTC](https://www.worldtimebuddy.com/mst-to-utc-converter?qm=1&lid=7,100,5128581&h=7&date=2021-4-21&sln=9-9.5&hf=1), where we discuss the latest developments and open questions.


### PR DESCRIPTION
Signed-off-by: Paul Jickling <paul.jickling@ethereum.org>

Saw that the FAQ listed the old `#portal-network` channel instead of the current Discord server, so I updated with a link.